### PR TITLE
Two minor fixes in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,8 +28,8 @@ cd ../..
 
 # Genometools
 cd ext
-wget -c https://github.com/genometools/genometools/archive/v1.5.6.tar.gz
+wget -c https://github.com/genometools/genometools/archive/v1.5.6.tar.gz -O v1.5.6.tar.gz
 tar xvf v1.5.6.tar.gz
 rm v1.5.6.tar.gz
 cd genometools-1.5.6
-make cairo=no
+make cairo=no errorcheck=no


### PR DESCRIPTION
1) Some older versions of wget (in my case, v1.11.4) don't automatically append the filetype to the downloaded file, so the path http://codeload.github.com/genometools/genometools/tar.gz/v1.5.6 is downloaded to "v1.5.6", not "v1.5.6.tar.gz" as the rest of the script expects.

This fix sets the output flag to the expected "v1.5.6.tar.gz".

2) The used version of genometools has some warnings about unused variables or warnings about Lua ("logical not is only applied to the left hand side of comparison") depending on the system's g++ and Lua versions, by default genometools treats warnings as errors which is not what anyone needs in this context.

This fix lets the warnings stay warnings. "make test cairo=no" in ext/genometools-1.5.6/ completes fine for me.
