### PR TITLE
make install.sh script take parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ project dir:
 
 Install flo's dependencies in `ext/` directory in the project dir:
 
-    /path/to/flo/scripts/install.sh
+    /path/to/flo/scripts/install.sh ucsc-kent parallel genometools
 
 Now edit `opts.yaml` to indicate:
 1. Location of source and target assembly in FASTA format (required).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 # UCSC-Kent
+if [[ "$*" == *"ucsc-kent"* ]] ## Check all the argument to the install.sh script
+then
 mkdir -p ext/kent/bin; cd ext/kent/bin
 tools=(liftUp faSplit liftOver axtChain chainNet blat/blat chainSort faToTwoBit
 twoBitInfo chainSplit chainMergeSort netChainSubset)
@@ -11,8 +13,11 @@ esac
 for tool in ${tools[@]}; do wget -c "${ftp_dir}/${tool}"; done
 chmod +x *
 cd -
+fi
 
 # GNU parallel
+if [[ "$*" == *"parallel"* ]] ## Check all the argument to the install.sh script
+then
 cd ext
 wget -c http://ftp.gnu.org/gnu/parallel/parallel-20150722.tar.bz2
 tar xvf parallel-20150722.tar.bz2
@@ -21,11 +26,15 @@ cd parallel-20150722
 ./configure
 make
 cd ../..
+fi
 
 # Genometools
+if [[ "$*" == *"genometools"* ]] ## Check all the argument to the install.sh script
+then
 cd ext
 wget -c https://github.com/genometools/genometools/archive/refs/tags/v1.6.2.tar.gz -O v1.6.2.tar.gz
 tar xvf v1.6.2.tar.gz
 rm v1.6.2.tar.gz
 cd genometools-1.6.2
 make cairo=no errorcheck=no
+fi


### PR DESCRIPTION
genometools was taking a long time to install (and I already had it via conda anyway), so I figured I'd slightly modify the install script so it could install only a subset of the dependencies. 